### PR TITLE
Add sticky header component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
 import Advantages from "@/components/Advantages";
@@ -7,6 +8,7 @@ import Footer from "@/components/Footer";
 export default function Home() {
   return (
     <main className="flex flex-col min-h-screen">
+      <Header />
       <Hero />
       <Services />
       <Advantages />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,22 @@
+export default function Header() {
+  return (
+    <header className="sticky top-0 bg-white/80 backdrop-blur">
+      <div className="max-w-5xl mx-auto flex items-center justify-between py-4 px-4">
+        <a href="#" className="font-bold text-xl">
+          VERTICO
+        </a>
+        <nav className="flex gap-4">
+          <a href="#services" className="hover:underline">
+            Services
+          </a>
+          <a href="#advantages" className="hover:underline">
+            Avantages
+          </a>
+          <a href="#contact" className="hover:underline">
+            Contact
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add sticky, semi-transparent header with anchor navigation
- render header above hero on home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6893e088dc3c832e965ae7fef7603fd7