### PR TITLE
feat: replace emojis with react-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.4.6",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5087,6 +5088,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.6"
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/components/Advantages.tsx
+++ b/src/components/Advantages.tsx
@@ -1,7 +1,9 @@
+import { FaCheckCircle, FaCogs, FaMedal } from "react-icons/fa";
+
 const points = [
-  { icon: "✅", title: "Fiable" },
-  { icon: "⚙️", title: "Fluide" },
-  { icon: "🏅", title: "Professionnel" },
+  { icon: FaCheckCircle, title: "Fiable" },
+  { icon: FaCogs, title: "Fluide" },
+  { icon: FaMedal, title: "Professionnel" },
 ];
 
 export default function Advantages() {
@@ -11,7 +13,9 @@ export default function Advantages() {
       <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
         {points.map((p) => (
           <div key={p.title} className="text-center flex flex-col items-center gap-2">
-            <div className="text-4xl">{p.icon}</div>
+            <div className="text-4xl text-orange-500">
+              <p.icon />
+            </div>
             <p className="text-lg font-medium">{p.title}</p>
           </div>
         ))}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,16 +1,18 @@
+import { FaTools, FaCouch, FaWater } from "react-icons/fa";
+
 const items = [
   {
-    icon: "🏗️",
+    icon: FaTools,
     title: "Gros œuvre",
     description: "Structures solides et durables pour tous vos projets",
   },
   {
-    icon: "🛋️",
+    icon: FaCouch,
     title: "Aménagement intérieur",
     description: "Espaces intérieurs fonctionnels et esthétiques",
   },
   {
-    icon: "💧",
+    icon: FaWater,
     title: "Hydraulique",
     description: "Pompes de forage et solutions hydrauliques",
   },
@@ -26,7 +28,9 @@ export default function Services() {
             key={item.title}
             className="bg-white p-6 rounded shadow text-center flex flex-col items-center gap-2"
           >
-            <div className="text-4xl">{item.icon}</div>
+            <div className="text-4xl text-orange-500">
+              <item.icon />
+            </div>
             <h3 className="text-xl font-semibold">{item.title}</h3>
             <p className="text-sm">{item.description}</p>
           </div>


### PR DESCRIPTION
## Summary
- use react-icons to render service cards
- adopt react-icons for advantages section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6893e2abf318832e98146b1bd5a9dfdb