### PR TITLE
feat: add accent color and apply to CTAs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,11 +3,13 @@
 :root {
   --background: #ffffff;
   --foreground: #1e3a8a; /* navy text */
+  --accent: #f97316; /* orange accent */
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
   --font-sans: var(--font-inter);
 }
 

--- a/src/components/Advantages.tsx
+++ b/src/components/Advantages.tsx
@@ -11,7 +11,7 @@ export default function Advantages() {
       <div className="max-w-5xl mx-auto grid gap-8 md:grid-cols-3">
         {points.map((p) => (
           <div key={p.title} className="text-center flex flex-col items-center gap-2">
-            <div className="text-4xl">{p.icon}</div>
+            <div className="text-4xl text-accent">{p.icon}</div>
             <p className="text-lg font-medium">{p.title}</p>
           </div>
         ))}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -19,7 +19,7 @@ export default function ContactForm() {
         />
         <button
           type="submit"
-          className="bg-orange-500 text-white font-semibold py-3 rounded hover:bg-orange-600"
+          className="bg-accent text-white font-semibold py-3 rounded hover:bg-accent/90"
         >
           Envoyer
         </button>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,7 +9,7 @@ export default function Hero() {
       </p>
       <Link
         href="#services"
-        className="bg-orange-500 text-white font-semibold px-6 py-3 rounded hover:bg-orange-600"
+        className="bg-accent text-white font-semibold px-6 py-3 rounded hover:bg-accent/90"
       >
         Découvrir nos services
       </Link>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -26,7 +26,7 @@ export default function Services() {
             key={item.title}
             className="bg-white p-6 rounded shadow text-center flex flex-col items-center gap-2"
           >
-            <div className="text-4xl">{item.icon}</div>
+            <div className="text-4xl text-accent">{item.icon}</div>
             <h3 className="text-xl font-semibold">{item.title}</h3>
             <p className="text-sm">{item.description}</p>
           </div>


### PR DESCRIPTION
## Summary
- add orange accent variable and expose it in the Tailwind theme
- use accent color for buttons and icon highlights

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_6893e2c3e188832e8dc18280623c295c