### PR TITLE
Avoid replaying intro video on home page revisit

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,21 @@ import VideoHero from "@/components/VideoHero";
 import NavigationDots from "@/components/NavigationDots";
 
 export default function HomePage() {
-  const [showDots, setShowDots] = useState(false);
+  const [showDots, setShowDots] = useState(() => {
+    if (typeof window !== "undefined") {
+      return sessionStorage.getItem("introPlayed") === "true";
+    }
+    return false;
+  });
+
+  const handleVideoEnd = () => {
+    sessionStorage.setItem("introPlayed", "true");
+    setShowDots(true);
+  };
 
   return (
     <main className="relative h-screen w-screen overflow-hidden bg-white">
-      <VideoHero onEnded={() => setShowDots(true)} />
+      {!showDots && <VideoHero onEnded={handleVideoEnd} />}
       {showDots && <NavigationDots />}
     </main>
   );


### PR DESCRIPTION
## Summary
- skip intro video on subsequent home page visits using sessionStorage
- hide video once ended and show navigation immediately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6895ef5819ac832e971859fe3894eb52