### PR TITLE
Fix lint error by escaping apostrophe in footer address

### DIFF
--- a/components/HomePageContent.tsx
+++ b/components/HomePageContent.tsx
@@ -275,7 +275,7 @@ export default function HomePageContent({ sections }: HomePageContentProps) {
               </div>
               <div>
                 <p className="font-medium text-orange-50">Adresse</p>
-                <p className="mt-1 text-orange-100/80">Abidjan, Côte d'Ivoire</p>
+                <p className="mt-1 text-orange-100/80">Abidjan, Côte d&apos;Ivoire</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- escape the apostrophe in the footer address to satisfy react/no-unescaped-entities linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68f20303c3b8832e81b18d3b9efe94fc